### PR TITLE
🧱 Add: ByteSentry Registry Contract + Mock Test Suite

### DIFF
--- a/contracts/registry.clar
+++ b/contracts/registry.clar
@@ -1,0 +1,136 @@
+;; ByteSentry - Registry Contract
+;; Author: @yourname
+;; Description: Registers protocols seeking audit scores and tracks metadata
+
+;; --------------------
+;; Constants & Errors
+;; --------------------
+
+(define-constant ERR-NOT-AUTHORIZED u100)
+(define-constant ERR-ALREADY-REGISTERED u101)
+(define-constant ERR-NOT-REGISTERED u102)
+(define-constant ERR-NOT-OWNER u103)
+
+;; --------------------
+;; Data Variables
+;; --------------------
+
+(define-data-var admin principal tx-sender)
+
+;; Protocol structure: owner, name, metadata (string), active status
+(define-map protocols principal 
+  {
+    owner: principal,
+    name: (string-utf8 64),
+    meta: (string-utf8 256),
+    active: bool
+  }
+)
+
+;; --------------------
+;; Private Helpers
+;; --------------------
+
+(define-private (is-admin (caller principal))
+  (is-eq caller (var-get admin))
+)
+
+(define-private (only-admin)
+  (asserts! (is-admin tx-sender) (err ERR-NOT-AUTHORIZED))
+)
+
+(define-private (is-protocol-owner (protocol principal))
+  (match (map-get? protocols protocol)
+    entry (is-eq tx-sender (get owner entry))
+    false
+  )
+)
+
+;; --------------------
+;; Public Functions
+;; --------------------
+
+(define-public (register-protocol (protocol principal) (name (string-utf8 64)) (meta (string-utf8 256)))
+  (begin
+    (only-admin)
+    (asserts! (is-none (map-get? protocols protocol)) (err ERR-ALREADY-REGISTERED))
+    (map-set protocols protocol {
+      owner: protocol,
+      name: name,
+      meta: meta,
+      active: true
+    })
+    (ok true)
+  )
+)
+
+(define-public (deactivate-protocol (protocol principal))
+  (begin
+    (asserts! (is-protocol-owner protocol) (err ERR-NOT-OWNER))
+    (match (map-get? protocols protocol)
+      entry (map-set protocols protocol (merge entry { active: false }))
+      (err ERR-NOT-REGISTERED)
+    )
+    (ok true)
+  )
+)
+
+(define-public (update-metadata (protocol principal) (new-meta (string-utf8 256)))
+  (begin
+    (asserts! (is-protocol-owner protocol) (err ERR-NOT-OWNER))
+    (match (map-get? protocols protocol)
+      entry (map-set protocols protocol (merge entry { meta: new-meta }))
+      (err ERR-NOT-REGISTERED)
+    )
+    (ok true)
+  )
+)
+
+(define-public (transfer-ownership (protocol principal) (new-owner principal))
+  (begin
+    (asserts! (is-protocol-owner protocol) (err ERR-NOT-OWNER))
+    (match (map-get? protocols protocol)
+      entry (map-set protocols protocol (merge entry { owner: new-owner }))
+      (err ERR-NOT-REGISTERED)
+    )
+    (ok true)
+  )
+)
+
+(define-public (transfer-admin (new-admin principal))
+  (begin
+    (only-admin)
+    (var-set admin new-admin)
+    (ok true)
+  )
+)
+
+;; --------------------
+;; Read-Only Functions
+;; --------------------
+
+(define-read-only (get-protocol (protocol principal))
+  (match (map-get? protocols protocol)
+    entry (ok entry)
+    (err ERR-NOT-REGISTERED)
+  )
+)
+
+(define-read-only (is-registered (protocol principal))
+  (is-some (map-get? protocols protocol))
+)
+
+(define-read-only (is-active (protocol principal))
+  (match (map-get? protocols protocol)
+    entry (get active entry)
+    false
+  )
+)
+
+(define-read-only (get-admin)
+  (ok (var-get admin))
+)
+
+;; ---------------
+;; END OF CONTRACT
+;; ---------------

--- a/deployments/default.simnet-plan.yaml
+++ b/deployments/default.simnet-plan.yaml
@@ -1,0 +1,59 @@
+---
+id: 0
+name: "Simulated deployment, used as a default for `clarinet console`, `clarinet test` and `clarinet check`"
+network: simnet
+genesis:
+  wallets:
+    - name: deployer
+      address: ST1PQHQKV0RJXZFY1DGX8MNSNYVE3VGZJSRTPGZGM
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: faucet
+      address: STNHKEPYEPJ8ET55ZZ0M5A34J0R3N5FM2CMMMAZ6
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_1
+      address: ST1SJ3DTE5DN7X54YDH5D64R3BCB6A2AG2ZQ8YPD5
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_2
+      address: ST2CY5V39NHDPWSXMW9QDT3HC3GD6Q6XX4CFRK9AG
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_3
+      address: ST2JHG361ZXG51QTKY2NQCVBPPRRE2KZB1HR05NNC
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_4
+      address: ST2NEB84ASENDXKYGJPQW86YXQCEFEX2ZQPG87ND
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_5
+      address: ST2REHHS5J3CERCRBEPMGH7921Q6PYKAADT7JP2VB
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_6
+      address: ST3AM1A56AK2C1XAFJ4115ZSV26EB49BVQ10MGCS0
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_7
+      address: ST3PF13W7Z0RRM42A8VZRVFQ75SV1K26RXEP8YGKJ
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+    - name: wallet_8
+      address: ST3NBRSFKX28FQ2ZJ1MAKX58HKHSDGNV5N7R21XCP
+      balance: "100000000000000"
+      sbtc-balance: "1000000000"
+  contracts:
+    - costs
+    - pox
+    - pox-2
+    - pox-3
+    - pox-4
+    - lockup
+    - costs-2
+    - costs-3
+    - cost-voting
+    - bns
+plan:
+  batches: []

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,137 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+
+const mockRegistryContract = {
+  admin: 'ST000ADMIN0000000000000000000000000000',
+  protocols: new Map(),
+
+  isAdmin(caller: string) {
+    return caller === this.admin
+  },
+
+  registerProtocol(caller: string, protocol: string, name: string, meta: string) {
+    if (!this.isAdmin(caller)) {
+      return { error: 100 } // ERR-NOT-AUTHORIZED
+    }
+    if (this.protocols.has(protocol)) {
+      return { error: 101 } // ERR-ALREADY-REGISTERED
+    }
+    this.protocols.set(protocol, {
+      owner: protocol,
+      name,
+      meta,
+      active: true,
+    })
+    return { value: true }
+  },
+
+  deactivateProtocol(caller: string, protocol: string) {
+    const entry = this.protocols.get(protocol)
+    if (!entry) return { error: 102 } // ERR-NOT-REGISTERED
+    if (caller !== entry.owner) return { error: 103 } // ERR-NOT-OWNER
+    this.protocols.set(protocol, { ...entry, active: false })
+    return { value: true }
+  },
+
+  updateMetadata(caller: string, protocol: string, newMeta: string) {
+    const entry = this.protocols.get(protocol)
+    if (!entry) return { error: 102 }
+    if (caller !== entry.owner) return { error: 103 }
+    this.protocols.set(protocol, { ...entry, meta: newMeta })
+    return { value: true }
+  },
+
+  transferOwnership(caller: string, protocol: string, newOwner: string) {
+    const entry = this.protocols.get(protocol)
+    if (!entry) return { error: 102 }
+    if (caller !== entry.owner) return { error: 103 }
+    this.protocols.set(protocol, { ...entry, owner: newOwner })
+    return { value: true }
+  },
+
+  transferAdmin(caller: string, newAdmin: string) {
+    if (!this.isAdmin(caller)) return { error: 100 }
+    this.admin = newAdmin
+    return { value: true }
+  },
+
+  getProtocol(protocol: string) {
+    return this.protocols.get(protocol) || null
+  },
+
+  isRegistered(protocol: string) {
+    return this.protocols.has(protocol)
+  },
+
+  isActive(protocol: string) {
+    const entry = this.protocols.get(protocol)
+    return entry ? entry.active : false
+  },
+}
+
+describe('ByteSentry Registry Contract (Mock)', () => {
+  beforeEach(() => {
+    mockRegistryContract.admin = 'ST000ADMIN0000000000000000000000000000'
+    mockRegistryContract.protocols = new Map()
+  })
+
+  it('allows admin to register a new protocol', () => {
+    const result = mockRegistryContract.registerProtocol(
+      'ST000ADMIN0000000000000000000000000000',
+      'STPROT001',
+      'Test Protocol',
+      'Initial Metadata'
+    )
+    expect(result).toEqual({ value: true })
+    expect(mockRegistryContract.getProtocol('STPROT001')).toMatchObject({ name: 'Test Protocol' })
+  })
+
+  it('prevents non-admins from registering protocols', () => {
+    const result = mockRegistryContract.registerProtocol(
+      'STNOTADMIN',
+      'STPROT002',
+      'Invalid Protocol',
+      'Invalid Metadata'
+    )
+    expect(result).toEqual({ error: 100 })
+    expect(mockRegistryContract.isRegistered('STPROT002')).toBe(false)
+  })
+
+  it('does not allow duplicate protocol registration', () => {
+    mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT003', 'Alpha', 'Meta')
+    const result = mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT003', 'Beta', 'Meta')
+    expect(result).toEqual({ error: 101 })
+  })
+
+  it('allows the owner to deactivate a protocol', () => {
+    mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT004', 'Gamma', 'Meta')
+    const result = mockRegistryContract.deactivateProtocol('STPROT004', 'STPROT004')
+    expect(result).toEqual({ value: true })
+    expect(mockRegistryContract.isActive('STPROT004')).toBe(false)
+  })
+
+  it('prevents non-owners from deactivating protocols', () => {
+    mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT005', 'Delta', 'Meta')
+    const result = mockRegistryContract.deactivateProtocol('STHACKER', 'STPROT005')
+    expect(result).toEqual({ error: 103 })
+  })
+
+  it('updates metadata when called by the protocol owner', () => {
+    mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT006', 'Zeta', 'Meta')
+    const result = mockRegistryContract.updateMetadata('STPROT006', 'STPROT006', 'Updated Meta')
+    expect(result).toEqual({ value: true })
+    expect(mockRegistryContract.getProtocol('STPROT006')?.meta).toBe('Updated Meta')
+  })
+
+  it('transfers protocol ownership correctly', () => {
+    mockRegistryContract.registerProtocol('ST000ADMIN0000000000000000000000000000', 'STPROT007', 'Omega', 'Meta')
+    const result = mockRegistryContract.transferOwnership('STPROT007', 'STPROT007', 'STNEWOWNER')
+    expect(result).toEqual({ value: true })
+    expect(mockRegistryContract.getProtocol('STPROT007')?.owner).toBe('STNEWOWNER')
+  })
+
+  it('transfers admin role correctly', () => {
+    const result = mockRegistryContract.transferAdmin('ST000ADMIN0000000000000000000000000000', 'STNEWADMIN')
+    expect(result).toEqual({ value: true })
+    expect(mockRegistryContract.admin).toBe('STNEWADMIN')
+  })
+})


### PR DESCRIPTION
## 🧱 Add: ByteSentry Registry Contract + Mock Test Suite

### Overview

This PR introduces the foundational smart contract for the **ByteSentry Protocol Registry**, built in Clarity. It also includes a corresponding mock test suite in TypeScript using **Vitest**.

---

### 📜 Registry Contract Highlights

- **Registers smart contract protocols** for audit tracking
- Stores project metadata (name, description)
- Tracks protocol activity status (active/inactive)
- Allows **ownership transfer** and **admin-controlled registration**
- Enforces access control:
  - Admin-only registration
  - Owner-only updates and deactivation

---

### 🔐 Access Control

- `admin` is initialized at deployment
- Only the `admin` can register protocols
- Only the `owner` of a protocol can:
  - Deactivate it
  - Update metadata
  - Transfer ownership

---

### ✅ Included Smart Contract Functions

- `register-protocol`
- `deactivate-protocol`
- `update-metadata`
- `transfer-ownership`
- `transfer-admin`
- `get-protocol` (read-only)
- `is-registered` (read-only)
- `is-active` (read-only)
- `get-admin` (read-only)

---

### 🧪 Test Coverage (Mock in TypeScript)

- ✅ Admin can register protocols
- ✅ Non-admin cannot register
- ✅ Duplicate registrations are blocked
- ✅ Owners can deactivate their protocols
- ✅ Unauthorized deactivation is rejected
- ✅ Metadata can be updated by owners
- ✅ Ownership transfer is tested
- ✅ Admin role transfer is validated

---

### 🔧 Tech Stack

- **Smart Contract:** Clarity  
- **Tests:** TypeScript + Vitest (Mock State)

---

### 📁 Files Added

- `contracts/registry.clar`
- `tests/registry.test.ts`

---

### Next Steps

- [ ] Deploy to testnet with Clarinet
- [ ] Expand integration with Audit Submission contract
- [ ] Add end-to-end tests with Clarinet assertions

